### PR TITLE
added missing install instructions.

### DIFF
--- a/rqt_template/CMakeLists.txt
+++ b/rqt_template/CMakeLists.txt
@@ -128,7 +128,7 @@ install(DIRECTORY include/$${PROJECT_NAME}/
 )
 
 # uncomment, if this widget will be used by any other QObject (e.g., a widget)
-#install(DIRECTORY ${ui_INCLUDE_DIR}/..
+#install(DIRECTORY ${ui_INCLUDE_DIR}/
 #  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
 #)
 

--- a/rqt_template/CMakeLists.txt
+++ b/rqt_template/CMakeLists.txt
@@ -127,6 +127,11 @@ install(DIRECTORY include/$${PROJECT_NAME}/
   DESTINATION $${CATKIN_PACKAGE_INCLUDE_DESTINATION}
 )
 
+# uncomment, if this widget will be used by any other QObject (e.g., a widget)
+#install(DIRECTORY ${ui_INCLUDE_DIR}/..
+#  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+#)
+
 #install(
 #  DIRECTORY resource
 #  DESTINATION $${CATKIN_PACKAGE_SHARE_DESTINATION}


### PR DESCRIPTION
If a plugin depends on widgets in different packages/repositories (i.e., widget main_plugin includes a widget promoted to widget_in_different_package which itself has a .ui file) the installation fails, if the auto-generated ui headers are not exported to the install space.